### PR TITLE
Disable dictation and emoji menu items on Mac

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,12 @@ const {app, BrowserWindow, ipcMain, Menu, MenuItem, Tray, dialog, Notification} 
 const consts = require('./src/consts.js')
 const client = require('./src/client.js').init()
 const rl = require('readline').createInterface({input: client.socket})
+if (process.platform === 'darwin') {
+    const {systemPreferences} = require('electron')
+
+    systemPreferences.setUserDefault('NSDisabledDictationMenuItem', 'boolean', true)
+    systemPreferences.setUserDefault('NSDisabledCharacterPaletteMenuItem', 'boolean', true)
+}
 
 let callbacks = {};
 let counters = {};


### PR DESCRIPTION
In our app menu on mac, we see 2 additional items by default viz. 
1. Dictation Menu
2. Emoji Palette Menu

These are of no use to our app. Disabling them.

[Issue](https://github.com/ionosnetworks/qfx/issues/55)